### PR TITLE
Use Python3 for the format-moment command

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -300,7 +300,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>python main.py addFormat "{query}"</string>
+				<string>python3 main.py addFormat "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>
@@ -344,7 +344,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
-				<string>python main.py delFormat "{query}"</string>
+				<string>python3 main.py delFormat "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
It seems that these two "Run Script" blocks were missed from the migration to Python 3